### PR TITLE
add forestry cmd, bring back cli cmds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "license": "MIT",
   "author": "Peter Lloyd & John Foderaro",
   "scripts": {
-    "build": "./node_modules/.bin/gridsome build",
-    "develop": "./node_modules/.bin/gridsome develop",
-    "explore": "./node_modules/.bin/gridsome explore",
+    "build": "gridsome build",
+    "develop": "gridsome develop",
+    "explore": "gridsome explore",
+    "forestry": "./node_modules/.bin/gridsome develop",
     "lint": "eslint . --ext vue,js,jsx,ts,tsx"
   },
   "dependencies": {


### PR DESCRIPTION
- Reverts npm script changes to use the gridsome CLI again 
- Adds a new script for the Forestry preview server: `yarn run forestry`
- Once this is merged, someone needs to update Forestry to reflect the above