### PR TITLE
add caseStudy logic to home page

### DIFF
--- a/src/content/case-studies/bright-pink.json
+++ b/src/content/case-studies/bright-pink.json
@@ -3,6 +3,7 @@
     "behavior change",
     "issue education"
   ],
+  "featured": true,
   "title": "Bright Pink",
   "slug": "bright-pink",
   "heading1": "Reach young, black women with prevention info",

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -99,6 +99,23 @@
   </Layout>
 </template>
 
+<static-query>
+  query {
+    allCaseStudy {
+      edges {
+        node {
+          title
+          featured
+          heading1
+          body1
+          photo
+          path
+        }
+      }
+    }
+  }
+</static-query>
+
 <script>
 import ApproachCard from '@/components/homepage/ApproachCard.vue'
 import AsideBox from '@/components/global/AsideBox.vue'
@@ -129,9 +146,12 @@ export default {
   },
   data () {
     return {
-      // TODO: Return array of isFeatured = true items to display on homepage
       caseStudiesList: []
     }
+  },
+  mounted () {
+    const allCaseStudies = this.$static.allCaseStudy.edges
+    this.caseStudiesList = allCaseStudies.filter((c) => c.node.featured)
   }
 }
 </script>


### PR DESCRIPTION
Closes #24 

- Added a toggle field in Forestry for `featured` prop on case study json documents
- Home page now filters by `featured` and then passes `caseStudiesList` to the child component