### PR TITLE
add active class functionality to tag nav

### DIFF
--- a/src/components/CaseStudyFilter.vue
+++ b/src/components/CaseStudyFilter.vue
@@ -53,6 +53,8 @@
 </template>
 
 <script>
+const activeClass = 'active'
+const activeDefault = 'all'
 export default {
   props: {
     tagHandler: {
@@ -60,9 +62,17 @@ export default {
       required: true
     }
   },
+  mounted () {
+    this.activeElement = document.querySelector(`[data-tag='${activeDefault}']`)
+    this.activeElement.classList.add(activeClass)
+  },
   methods: {
     onClick (event) {
-      const tag = event.target.dataset.tag
+      const { target } = event
+      const tag = target.dataset.tag
+      this.activeElement.classList.remove(activeClass)
+      this.activeElement = target
+      this.activeElement.classList.add(activeClass)
       tag && this.tagHandler(tag)
     }
   }

--- a/src/components/CaseStudyFilter.vue
+++ b/src/components/CaseStudyFilter.vue
@@ -63,7 +63,7 @@ export default {
     }
   },
   mounted () {
-    this.activeElement = document.querySelector(`[data-tag='${activeDefault}']`)
+    this.activeElement = document.querySelector(`[data-category='${activeDefault}']`)
     this.activeElement.classList.add(activeClass)
   },
   methods: {

--- a/src/components/CaseStudyFilter.vue
+++ b/src/components/CaseStudyFilter.vue
@@ -15,35 +15,35 @@
         <a
           data-category="all"
           href="#"
-          class="mr-4 text-sm tracking-wider text-gray-600 uppercase din"
+          class="relative mr-4 text-sm tracking-wider text-gray-600 uppercase din"
         >
           All
         </a>
         <a
           data-category="issueEducation"
           href="#"
-          class="mr-4 text-sm tracking-wider text-gray-600 uppercase din"
+          class="relative mr-4 text-sm tracking-wider text-gray-600 uppercase din"
         >
           Issue Education
         </a>
         <a
           data-category="behaviorChange"
           href="#"
-          class="mr-4 text-sm tracking-wider text-gray-600 uppercase din"
+          class="relative mr-4 text-sm tracking-wider text-gray-600 uppercase din"
         >
           Behavior Change
         </a>
         <a
           data-category="programGrowthDelivery"
           href="#"
-          class="mr-4 text-sm tracking-wider text-gray-600 uppercase din"
+          class="relative mr-4 text-sm tracking-wider text-gray-600 uppercase din"
         >
           Program Growth &amp; Delivery
         </a>
         <a
           data-category="leadGeneration"
           href="#"
-          class="text-sm tracking-wider text-gray-600 uppercase din"
+          class="relative text-sm tracking-wider text-gray-600 uppercase din"
         >
           Lead Generation
         </a>
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-const activeClass = 'active'
+const activeClass = 'active-tag'
 const activeDefault = 'all'
 export default {
   props: {
@@ -84,6 +84,18 @@ export default {
 .title-box {
   @media (min-width: 768px) {
     width: calc(50% - 410px);
+  }
+}
+
+.active-tag {
+  &::after {
+    content: '';
+    position: absolute;
+    border-bottom: 2px solid #fadd0d;
+    width: 100%;
+    height: 2px;
+    left: 0;
+    bottom: -2px;
   }
 }
 


### PR DESCRIPTION
Closes #31 

- Adds a CSS class to whatever the default item should be (currently "all") upon mount
- Removes existing active CSS class on click and assigns it to item that was clicked

I'm not sure what the actual CSS class is, but this can be changed easily on line 56 (https://github.com/plloyd11/craftand/compare/activeState?expand=1#diff-a2efa145343eebee2c6b405abd6e93bdR56) 

