### PR TITLE
add youtube embed concept

### DIFF
--- a/src/content/case-studies/bay-area-metropolitan-transportation-commission.json
+++ b/src/content/case-studies/bay-area-metropolitan-transportation-commission.json
@@ -9,7 +9,7 @@
   "supportiveText": "MTC received 10,000+ inputs to PBA 2050 from 3,000+ game players",
   "yellowBoxHeadline": "Teasing the Game",
   "yellowBoxContent": "Snapchat, Facebook and IG stories gave us a platform to hook residents on the challenge of playing the game.",
-  "videoPoster": "../../assets/img/craft/video-poster.png",
+  "youtubeLink": "",
   "clientTestimony": "Hey hey",
   "clientTitle": "the stuff",
   "categories": {

--- a/src/content/case-studies/bright-pink.json
+++ b/src/content/case-studies/bright-pink.json
@@ -9,7 +9,7 @@
   "supportiveText": "Coupled with an average of 0:38 time on content",
   "yellowBoxHeadline": "What we learned along the way",
   "yellowBoxContent": "When we began this project with Carton Council, Messenger chatbots were relatively new, and we were cautiously optimistic that it could be a good tool for this kind of information-heavy campaign where we aim to gather emails. The results far exceeded expectations, and offered a third benefit we hadn’t anticipated: it allowed us to track intent to recycle, too, opening up the possibility of personalized, ongoing recycling reminders.",
-  "videoPoster": "../../assets/img/craft/video-poster.png",
+  "youtubeLink": "https://youtu.be/isfvb5ZDOCw",
   "categories": {
     "issueEducation": true,
     "behaviorChange": true,

--- a/src/content/case-studies/carton-council.json
+++ b/src/content/case-studies/carton-council.json
@@ -2,7 +2,7 @@
   "featured": true,
   "slug": "carton-council",
   "photo": "../../assets/img/craft/carton-hero.png",
-  "videoPoster": "../../assets/img/craft/video-poster.png",
+  "youtubeLink": "",
   "categories": {
     "issueEducation": false,
     "behaviorChange": true,

--- a/src/content/case-studies/girl-scouts-usa.json
+++ b/src/content/case-studies/girl-scouts-usa.json
@@ -18,7 +18,7 @@
   ],
   "yellowBoxHeadline": "This was a great Campaign",
   "yellowBoxContent": "We did an awesome job!",
-  "videoPoster": "../../assets/img/craft/video-poster.png",
+  "youtubeLink": "",
   "clientTestimony": "\"What an amazing campaign this was!\"",
   "clientTitle": "Client Name\nHead of the Girl Scouts USA"
 }

--- a/src/content/case-studies/new-americans-campaign.json
+++ b/src/content/case-studies/new-americans-campaign.json
@@ -4,7 +4,7 @@
   "heading1": "Engaged and activated diverse immigrant communities",
   "body1": "C&C partnered with the New Americans Campaign on a nationwide effort to connect with Legal Permanent Residents and guide qualified LPRs through the process of applying for U.S. citizenship. Effectively engaging these diverse communities required cultural sensitivity around tone, imagery, and language, which C&C achieved through rigorous ad testing and learning.",
   "photo": "../../assets/img/craft/nac.png",
-  "videoPoster": "../../assets/img/craft/video-poster.png",
+  "youtubeLink": "",
   "categories": {
     "issueEducation": false,
     "behaviorChange": false,

--- a/src/templates/CaseStudy.vue
+++ b/src/templates/CaseStudy.vue
@@ -83,14 +83,16 @@
     </section>
     <!-- Video -->
     <section v-if="$page.caseStudy.youtubeLink">
-      <iframe
-        width="560"
-        height="315"
-        frameborder="0"
-        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        :src="`https://www.youtube.com/embed/${$page.caseStudy.youtubeLink.split('/').pop()}`"
-      />
+      <div class="container mx-auto">
+        <iframe
+          width="100%"
+          frameborder="0"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+          class="youtube-container"
+          :src="`https://www.youtube.com/embed/${$page.caseStudy.youtubeLink.split('/').pop()}`"
+        />
+      </div>
     </section>
     <!-- Quote -->
     <section
@@ -205,6 +207,13 @@ export default {
   width: 100%;
   background: url('~@/assets/img/global/yellow-decorated-rectangle.jpg') no-repeat center center;
   background-size: cover;
+}
+
+.youtube-container {
+  height: 400px;
+  @media (min-width: 768px) {
+    height: 800px;
+  }
 }
 
 </style>

--- a/src/templates/CaseStudy.vue
+++ b/src/templates/CaseStudy.vue
@@ -82,8 +82,15 @@
       </div>
     </section>
     <!-- Video -->
-    <section>
-      <g-image :src="$page.caseStudy.videoPoster" />
+    <section v-if="$page.caseStudy.youtubeLink">
+      <iframe
+        width="560"
+        height="315"
+        frameborder="0"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        :src="`https://www.youtube.com/embed/${$page.caseStudy.youtubeLink.split('/').pop()}`"
+      />
     </section>
     <!-- Quote -->
     <section
@@ -131,7 +138,7 @@
       supportiveText
       yellowBoxHeadline
       yellowBoxContent
-      videoPoster
+      youtubeLink
       clientTestimony
       clientTitle
     }


### PR DESCRIPTION
Closes #35 

Updated Forestry to have a field "YouTube Link" with description text that explains they should be entering the "share" link from a YouTube video. This is safer than rendering arbitrary HTML that a user places into Forestry: 

<img width="516" alt="Screen Shot 2020-02-16 at 7 08 01 PM" src="https://user-images.githubusercontent.com/7059639/74615527-b5757100-50ef-11ea-8221-947ac4862971.png">

The Case Study component then splits the URL on the forward slashes and grabs the last chunk, using that in the embed iframe.

The iframe will need some work to make it fit the style/layout as I just grabbed the YouTube provided iframe HTML and placed it in.


